### PR TITLE
chore: Use rimraf instead of rm -rf

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
 		"lint": "eslint src --ext ts",
 		"prettier:check": "prettier --list-different \"src/**/*.{ts,tsx}\"",
 		"prettier:write": "prettier --write \"src/**/*.{ts,tsx}\"",
-		"test": "rm -rf dist & tsc && ava dist/test/**/*.spec.js -- $LINE",
-		"test:watch": "rm -rf dist && tsc --watch & ava dist/test/**/*.spec.js --watch",
-		"watch": "rm -rf lib && rollup -c --watch",
-		"build": "rm -rf lib && rollup -c"
+		"test": "rimraf dist & tsc && ava dist/test/**/*.spec.js -- $LINE",
+		"test:watch": "rimraf dist && tsc --watch & ava dist/test/**/*.spec.js --watch",
+		"watch": "rimraf lib && rollup -c --watch",
+		"build": "rimraf lib && rollup -c"
 	},
 	"main": "lib/index.cjs.js",
 	"typings": "lib/index.cjs.d.ts",
@@ -44,6 +44,7 @@
 		"husky": "^1.3.1",
 		"prettier": "^1.15.3",
 		"pretty-quick": "^1.8.0",
+		"rimraf": "^2.6.3",
 		"rollup": "^0.67.4",
 		"standard-version": "^4.4.0",
 		"typescript": "^3.4.0"


### PR DESCRIPTION
Some npm scripts were using rm -rf to clean the package. Unfortunately,
Windows does not come with rm -rf built-in. rimraf provides the same
functionality as an npm package.

This change replaces rm -rf calls with rimraf and installs it as a
devDependency so that the scripts work on Windows out-of the box.