### PR TITLE
chore: Remove esModuleInterop from tsconfig.json

### DIFF
--- a/test/compile.ts
+++ b/test/compile.ts
@@ -1,20 +1,20 @@
-import ts, { Diagnostic, CompilerOptions, SourceFile } from "typescript";
+import { createProgram, Diagnostic, CompilerOptions, getPreEmitDiagnostics, Program, ModuleKind, ScriptTarget, SourceFile } from "typescript";
 
 const defaultOptions: CompilerOptions = {
 	noEmitOnError: true,
 	noImplicitAny: true,
-	target: ts.ScriptTarget.ES5,
-	module: ts.ModuleKind.CommonJS,
+	target: ScriptTarget.ES5,
+	module: ModuleKind.CommonJS,
 	strict: true
 };
 
-export function compile(filePath: string, options: Partial<CompilerOptions> = {}): { sourceFile: SourceFile, diagnostics: ReadonlyArray<Diagnostic>, program: ts.Program } {
-	const program = ts.createProgram([filePath], {...defaultOptions, ...options});
+export function compile(filePath: string, options: Partial<CompilerOptions> = {}): { sourceFile: SourceFile; diagnostics: ReadonlyArray<Diagnostic>; program: Program } {
+	const program = createProgram([filePath], { ...defaultOptions, ...options });
 	const sourceFile = program.getSourceFile(filePath);
 	if (sourceFile == null) throw new Error(`Couldn't find source file: ${filePath}`);
 
 	const emitResult = program.emit();
-	const diagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+	const diagnostics = getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
 
-	return { sourceFile, diagnostics, program }
+	return { sourceFile, diagnostics, program };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
 		"outDir": "./dist",
 		"downlevelIteration": true,
 		"strict": true,
-		"esModuleInterop": true,
 		"noImplicitAny": true,
 		"allowUnusedLabels": false,
 		"allowUnreachableCode": false,


### PR DESCRIPTION
This change removes esModuleInterop from tsconfig.json. Interop only
seems to be used in one file and is likely unnecessary. Resources from
the module that needed interop are now being imported directly.