### PR TITLE
Relax check in extendTypeParameterMap

### DIFF
--- a/src/is-assignable-to-simple-type.ts
+++ b/src/is-assignable-to-simple-type.ts
@@ -428,6 +428,5 @@ function extendTypeParameterMap(genericType: SimpleTypeGenericArguments, existin
 		return new Map(allParameterEntries);
 	}
 
-	throw new Error(`Couldn't find 'typeParameter' for type '${genericType.target.kind}'`);
-	//return existingMap;
+	return existingMap;
 }


### PR DESCRIPTION
This is crashing when comparing an instance of an empty class against a primitive type (e.g. a boolean). Showed up in writing tests for https://github.com/runem/lit-analyzer/issues/28