### PR TITLE
Always cache Type -> SimpleType relationship

### DIFF
--- a/src/to-simple-type.ts
+++ b/src/to-simple-type.ts
@@ -44,6 +44,8 @@ import {
 	isVoid
 } from "./ts-util";
 
+const defaultCache = new WeakMap<Type, SimpleType>();
+
 /**
  * Converts a Typescript type to a "SimpleType"
  * @param type The type to convert.
@@ -55,13 +57,13 @@ export function toSimpleType(type: Type, checker: TypeChecker, cache?: WeakMap<T
 export function toSimpleType(type: Type | Node, checker: TypeChecker, cache?: WeakMap<Type, SimpleType>): SimpleType {
 	if (isNode(type)) {
 		// "type" is a "Node", convert it to a "Type" and continue.
-		return toSimpleType(checker.getTypeAtLocation(type), checker);
+		return toSimpleType(checker.getTypeAtLocation(type), checker, cache);
 	}
-
+	cache = cache || defaultCache;
 	return toSimpleTypeInternalCaching(type, {
 		checker,
 		circularCache: new WeakMap<Type, SimpleType>(),
-		cache: cache || new WeakMap<Type, SimpleType>()
+		cache
 	});
 }
 


### PR DESCRIPTION
In the course of type checking very large programs with ts-simple-type, a lot of time can be spent repeatedly performing the same converstions from Type to SimpleType.

Something of a bold proposal, but what if we just cached all Type -> SimpleType relationships by default? Because they're stored in a WeakMap it only adds a constant factor onto the existing memory usage.

This change came about due to a google-internal codebase that has 45MB of .d.ts files as input(!), all of which were present in the global scope(!!) meaning that they hang off of `globalThis`, which `Window` now extends, so constructing the SimpleType of any element whose SimpleType referenced Window (however indirectly) would walk the entire type graph. web-component-analyzer does this many times, as it turns out, causing some serious thrashing. Compiling this project with ts-lit-plugin was taking >3 minutes.

This change takes their incremental compile timedown to  14 seconds. 93% less time!

Surprisingly, without ts-lit-plugin, the project compiles in under a second (with --skipLibCheck). I believe this is because TypeScript is architected to be lazy and only do work on demand, so when type checking a file it will attempt to do the minimum work necessary to type check the statements in that file. However, I'm not sure how this interacts with a number of other TS features, like interface merging, which require a degree of global knowledge. TS is also just highly optimized.